### PR TITLE
count query is always fetching all the records #RBST-13621

### DIFF
--- a/session.go
+++ b/session.go
@@ -4827,7 +4827,7 @@ func (q *Query) Count() (n int, err error) {
 		// get only collection name from full name, ex: only user from data_store.user
 		collectionName := strings.ReplaceAll(q.op.collection, fmt.Sprintf("%s.", q.session.dialInfo.Database), "")
 
-		count, err := db.Collection(collectionName).CountDocuments(context.Background(), q.query)
+		count, err := db.Collection(collectionName).CountDocuments(context.Background(), q.op.query)
 
 		return int(count), err
 	} else {


### PR DESCRIPTION
find query is maintained in the -> 'q.op.query'
but 'q.query' is used wrongly.