### PR TITLE
fix: Add trigger event handler to UpdateId for MongoDB driver

### DIFF
--- a/session.go
+++ b/session.go
@@ -3159,6 +3159,13 @@ func (c *Collection) UpdateId(id interface{}, update interface{}) error {
 			}
 		}
 		_, err := db.Collection(c.Name).UpdateByID(context.Background(), id, update)
+
+		// Trigger event handler for consistency with Update() method
+		if err == nil {
+			selector := bson.M{"_id": id}
+			handleEventsFunc(c.FullName, selector, update)
+		}
+
 		return err
 	} else {
 		return c.Update(bson.D{{Name: "_id", Value: id}}, update)


### PR DESCRIPTION
## Summary
- Fixed trigger events not firing when using `UpdateId` with MongoDB driver
- Added `handleEventsFunc` call to `UpdateId` for consistency with `Update()` method

## Problem
When using the MongoDB driver path in `UpdateId`, the function was not calling `handleEventsFunc`, causing triggers to not fire. The `Update()` method has this call, but `UpdateId` was missing it.

## Solution
Added the event handler call after successful `UpdateByID` operation:
```go
if err == nil {
    selector := bson.M{"_id": id}
    handleEventsFunc(c.FullName, selector, update)
}
```

## Test plan
- [ ] Verify triggers fire correctly when using `UpdateId` with MongoDB driver
- [ ] Ensure no regression in existing trigger functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)