### PR TITLE
feat: route Collection.EnsureIndex through MongoDB driver

### DIFF
--- a/session.go
+++ b/session.go
@@ -1775,6 +1775,77 @@ func (c *Collection) EnsureIndex(index Index) error {
 		return nil
 	}
 
+	if UseMongoDriver {
+		db := session.GetDriverDatabase()
+
+		keys := mongoDriverBson.D{}
+		for _, e := range keyInfo.key {
+			keys = append(keys, mongoDriverBson.E{Key: e.Name, Value: e.Value})
+		}
+
+		opts := options.Index()
+		switch {
+		case index.Name != "":
+			opts.SetName(index.Name)
+		case keyInfo.name != "":
+			opts.SetName(keyInfo.name)
+		}
+		if index.Unique {
+			opts.SetUnique(true)
+		}
+		if index.Background {
+			opts.SetBackground(true)
+		}
+		if index.Sparse {
+			opts.SetSparse(true)
+		}
+		if index.ExpireAfter > 0 {
+			opts.SetExpireAfterSeconds(int32(index.ExpireAfter / time.Second))
+		}
+		if index.PartialFilter != nil {
+			pf := mongoDriverBson.M{}
+			for k, v := range index.PartialFilter {
+				pf[k] = v
+			}
+			opts.SetPartialFilterExpression(pf)
+		}
+		if index.DefaultLanguage != "" {
+			opts.SetDefaultLanguage(index.DefaultLanguage)
+		}
+		if index.LanguageOverride != "" {
+			opts.SetLanguageOverride(index.LanguageOverride)
+		}
+		if len(keyInfo.weights) > 0 {
+			w := mongoDriverBson.D{}
+			for _, e := range keyInfo.weights {
+				w = append(w, mongoDriverBson.E{Key: e.Name, Value: e.Value})
+			}
+			opts.SetWeights(w)
+		}
+		if index.Collation != nil {
+			opts.SetCollation(&options.Collation{
+				Locale:          index.Collation.Locale,
+				CaseLevel:       index.Collation.CaseLevel,
+				CaseFirst:       index.Collation.CaseFirst,
+				Strength:        index.Collation.Strength,
+				NumericOrdering: index.Collation.NumericOrdering,
+				Alternate:       index.Collation.Alternate,
+				MaxVariable:     index.Collation.MaxVariable,
+				Normalization:   index.Collation.Normalization,
+				Backwards:       index.Collation.Backwards,
+			})
+		}
+
+		_, err := db.Collection(c.Name).Indexes().CreateOne(
+			context.Background(),
+			mongo.IndexModel{Keys: keys, Options: opts},
+		)
+		if err == nil {
+			session.cluster().CacheIndex(cacheKey, true)
+		}
+		return err
+	}
+
 	spec := indexSpec{
 		Name:                    keyInfo.name,
 		NS:                      c.FullName,


### PR DESCRIPTION
## Summary

When `SetMongoDriverUse(true)`, `Collection.EnsureIndex` now translates the mgo `Index` struct into a `mongo.IndexModel` and calls `Indexes().CreateOne` on the official driver, instead of falling through to `Database.Run` on the dummy mgo cluster (which has no live socket and segfaults).

Without this, any caller that holds a `mgo.Session` produced by `NewDummySession(...)` + `SetMongoDriverUse(true)` and calls `Collection.EnsureIndex(...)` panics with `runtime error: invalid memory address or nil pointer dereference` inside `mongoSocket.flushLogout`. Triaged in nerve where new `Ensure*Indexes` callers (MITM presets, MITM session/proto/instance/rule events, AppVitals summary/aggregate/build-compare/trend-compare) hit this on every startup. The pre-existing pattern of disabling `housekeeping.CreateIndexes()` in nerve's `main.go` was a workaround for the same root cause.

## Scope of the bridge

The new `if UseMongoDriver { ... }` branch covers:
- Keys (mgo `bson.D` → `mongoDriverBson.D`, including descending and special types via existing `parseIndexKey`)
- Name (explicit `index.Name`, falling back to computed `keyInfo.name`)
- Unique, Background, Sparse
- ExpireAfter (TTL)
- PartialFilter (`bson.M`)
- DefaultLanguage, LanguageOverride
- Weights (text indexes)
- Collation (all 9 fields)

Falls through to the legacy mgo path when `UseMongoDriver` is false. The existing `session.cluster().CacheIndex(...)` hook is preserved on success.

## Test plan

- [x] Build the fork standalone: `go build ./...` clean.
- [x] Build a downstream consumer (nerve) with `replace github.com/izinga/mgo => <local>`: clean.
- [x] Start nerve against MongoDB 4 with `use_mgo_driver: no`. Previously: SIGSEGV in `EnsureMITMConfigPresetIndexes` at startup. After the patch: nerve starts cleanly; all 9 collections (`mitmConfigPreset`, `mitmSessionConfig`, `mitmProtoDesc`, `mitmInstance`, `mitmRuleEvent`, `appvitalsSummary`, `appvitalsAggregate`, `appvitalsBuildCompare`, `appvitalsTrendCompare`) have their full index sets created — including unique (`org_name_unique`), TTL (`archivedAt_ttl`, `at_ttl`), and compound descending (`org_lastUsed`, `group_startTime`) indexes.
- [x] Existing CRUD bridges (`Insert`, `Update*`, `Remove*`, `Query.One/All/Count/Distinct/Apply`) are unchanged — diff is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)